### PR TITLE
Add retry mechanism

### DIFF
--- a/src/__tests__/test-utils.ts
+++ b/src/__tests__/test-utils.ts
@@ -1,3 +1,5 @@
+import { logger } from '@/logging/logger';
+
 /**
  * Stops execution for {@link milliseconds} milliseconds.
  */
@@ -6,20 +8,13 @@ export async function milliseconds(milliseconds: number): Promise<void> {
 }
 
 /**
- * Stops execution for {@link seconds} seconds.
- */
-export async function seconds(seconds: number): Promise<void> {
-  return milliseconds(seconds * 1000);
-}
-
-/**
  * Executes the function {@link fn}, retrying if it throws an error.
  * Uses a linear strategy by retrying each {@link delayMs} milliseconds.
  * If {@link maxAttempts} is reached, it throws the error returned by {@link fn} last execution.
  */
-export function retry(
+export async function retry(
   fn: () => void,
-  maxAttempts: number = 10,
+  maxAttempts: number = 30,
   delayMs: number = 1000,
 ) {
   let attempt = 1;
@@ -27,7 +22,10 @@ export function retry(
     try {
       return await fn();
     } catch (error) {
-      if (attempt >= maxAttempts) throw error;
+      if (attempt >= maxAttempts) {
+        logger.error({ msg: 'Exhausted retries', attempt, maxAttempts });
+        throw error;
+      }
     }
 
     await milliseconds(delayMs);

--- a/src/__tests__/test-utils.ts
+++ b/src/__tests__/test-utils.ts
@@ -23,7 +23,7 @@ export async function retry(
       return await fn();
     } catch (error) {
       if (attempt >= maxAttempts) {
-        logger.error({ msg: 'Exhausted retries', attempt, maxAttempts });
+        logger.error({ msg: 'Exhausted retries', delayMs, maxAttempts });
         throw error;
       }
     }

--- a/src/__tests__/test-utils.ts
+++ b/src/__tests__/test-utils.ts
@@ -11,3 +11,28 @@ export async function milliseconds(milliseconds: number): Promise<void> {
 export async function seconds(seconds: number): Promise<void> {
   return milliseconds(seconds * 1000);
 }
+
+/**
+ * Executes the function {@link fn}, retrying if it throws an error.
+ * Uses a linear strategy by retrying each {@link delayMs} milliseconds.
+ * If {@link maxAttempts} is reached, it throws the error returned by {@link fn} last execution.
+ */
+export function retry(
+  fn: () => void,
+  maxAttempts: number = 10,
+  delayMs: number = 1000,
+) {
+  let attempt = 1;
+  const execute = async () => {
+    try {
+      return await fn();
+    } catch (error) {
+      if (attempt >= maxAttempts) throw error;
+    }
+
+    await milliseconds(delayMs);
+    attempt++;
+    return execute();
+  };
+  return execute();
+}

--- a/src/__tests__/use-cases/transfers/manage-native-coins.spec.ts
+++ b/src/__tests__/use-cases/transfers/manage-native-coins.spec.ts
@@ -1,4 +1,4 @@
-import { seconds } from '@/__tests__/test-utils';
+import { retry, seconds } from '@/__tests__/test-utils';
 import { configuration } from '@/config/configuration';
 import {
   CGWDeleteTransactionDTO,
@@ -62,8 +62,8 @@ describe('Transactions cleanup', () => {
   }, 120_000);
 });
 
-describe('Transfers: receive/send native coins from/to EOA', () => {
-  it('should receive an ether transfer and check it is on the CGW history', async () => {
+describe.only('Transfers: receive/send native coins from/to EOA', () => {
+  it.only('should receive an ether transfer and check it is on the CGW history', async () => {
     const safeAddress = await sdkInstance.getAddress();
     const safeBalance = await sdkInstance.getBalance();
     const amount = ethers.parseUnits('0.0001', 'ether');
@@ -72,12 +72,15 @@ describe('Transfers: receive/send native coins from/to EOA', () => {
       to: safeAddress,
       value: amount,
     });
-    await seconds(30);
 
-    const historyTxs = await cgw.getHistory(safeAddress);
-    const newBalance = await sdkInstance.getBalance();
-    expect(containsTransaction(historyTxs, tx.hash)).toBe(true);
-    expect(newBalance).toEqual(safeBalance + amount);
+    const checks = async () => {
+      const historyTxs = await cgw.getHistory(safeAddress);
+      const newBalance = await sdkInstance.getBalance();
+      expect(containsTransaction(historyTxs, tx.hash)).toBe(true);
+      expect(newBalance).toEqual(safeBalance + amount);
+    };
+
+    retry(checks);
   });
 
   it.skip('should propose an ether transfer, check queue, and delete the proposed transaction', async () => {


### PR DESCRIPTION
## Summary
Add a retry mechanism that executes a function until it does not throw. This `retry` function can be used to test assertions repeatedly until they become eventually verified.

## Changes
- Deprecate `seconds(seconds: number)` in favor of `retry(fn: () => void, maxAttempts: number, delayMs: number)`.