### PR TITLE
Augment global test timeout

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,5 +6,5 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testRegex: '.*\\.spec\\.ts$',
-  testTimeout: 120_000,
+  testTimeout: 250_000,
 };


### PR DESCRIPTION
## Changes
- Augments the global test timeout to 250 seconds, in order to accommodate it to the maximum number of retries configured in `test-utils.ts`.