### PR TITLE
Renames CGW entity property Account.accountId to Account.id

### DIFF
--- a/src/__tests__/cgw/accounts.spec.ts
+++ b/src/__tests__/cgw/accounts.spec.ts
@@ -46,7 +46,7 @@ describe('CGW Auth tests', () => {
         expect(created.address).toBe(address);
         const account = await cgw.getAccount(accessToken, created.address);
         expect(account.address).toBe(created.address);
-        expect(account.accountId).toBe(created.accountId);
+        expect(account.id).toBe(created.id);
       } finally {
         await cgw.deleteAccount(accessToken, address);
       }
@@ -86,7 +86,7 @@ describe('CGW Auth tests', () => {
         expect(created.address).toBe(address);
         const account = await cgw.getAccount(accessToken, created.address);
         expect(account.address).toBe(created.address);
-        expect(account.accountId).toBe(created.accountId);
+        expect(account.id).toBe(created.id);
         const dataTypes = await cgw.getDataTypes();
         const upsertAccountDataSettingsDto = {
           accountDataSettings: dataTypes

--- a/src/datasources/cgw/cgw-client.ts
+++ b/src/datasources/cgw/cgw-client.ts
@@ -82,11 +82,11 @@ export interface SiweDto {
 }
 
 export interface CGWCreateAccountDto {
-  address: string;
+  address: `0x${string}`;
 }
 
 export interface CGWAccount {
-  accountId: string;
+  id: string;
   groupId: string | null;
   address: string;
 }
@@ -98,11 +98,13 @@ export interface CGWDataType {
   isActive: boolean;
 }
 
+export interface CGWAccountDataSetting {
+  dataTypeId: string;
+  enabled: boolean;
+}
+
 export interface CGWUpsertAccountDataSettingsDto {
-  accountDataSettings: {
-    dataTypeId: string;
-    enabled: boolean;
-  }[];
+  accountDataSettings: CGWAccountDataSetting[];
 }
 
 export class ClientGatewayClient {


### PR DESCRIPTION
## Changes
- Renames `Account.accountId` to `Account.id` in concordance with https://github.com/safe-global/safe-client-gateway/pull/1772