### PR TITLE
Fix TransactionResponse type

### DIFF
--- a/src/__tests__/use-cases/transfers/ether-between-safes.spec.ts
+++ b/src/__tests__/use-cases/transfers/ether-between-safes.spec.ts
@@ -11,7 +11,7 @@ import { faker } from '@faker-js/faker';
 import SafeApiKit from '@safe-global/api-kit';
 import Safe from '@safe-global/protocol-kit';
 import { MetaTransactionData } from '@safe-global/safe-core-sdk-types';
-import { Wallet, ethers } from 'ethers';
+import { TransactionResponse, Wallet, ethers } from 'ethers';
 
 let eoaSigner: Wallet;
 let primarySafeSdkInstance: Safe;
@@ -98,7 +98,11 @@ describe('Transfers: receive/send native coins between Safes', () => {
     const safeTransaction = await apiKit.getTransaction(safeTxHash);
     const executeTxResponse =
       await primarySafeSdkInstance.executeTransaction(safeTransaction);
-    await executeTxResponse.transactionResponse?.wait();
+    if (executeTxResponse.transactionResponse) {
+      await (
+        executeTxResponse.transactionResponse as TransactionResponse
+      ).wait();
+    }
 
     // Check the CGW history contains the transaction
     await retry(async () => {

--- a/src/__tests__/use-cases/transfers/manage-native-coins.spec.ts
+++ b/src/__tests__/use-cases/transfers/manage-native-coins.spec.ts
@@ -58,7 +58,11 @@ describe('Transactions cleanup', () => {
       const safeTransaction = await apiKit.getTransaction(tx.safeTxHash);
       const executeTxResponse =
         await sdkInstance.executeTransaction(safeTransaction);
-      await executeTxResponse.transactionResponse?.wait();
+      if (executeTxResponse.transactionResponse) {
+        await (
+          executeTxResponse.transactionResponse as TransactionResponse
+        ).wait();
+      }
 
       // Check the CGW history contains the transaction
       await retry(async () => {
@@ -196,7 +200,11 @@ describe('Transfers: receive/send native coins from/to EOA', () => {
     const safeTransaction = await apiKit.getTransaction(safeTxHash);
     const executeTxResponse =
       await sdkInstance.executeTransaction(safeTransaction);
-    await executeTxResponse.transactionResponse?.wait();
+    if (executeTxResponse.transactionResponse) {
+      await (
+        executeTxResponse.transactionResponse as TransactionResponse
+      ).wait();
+    }
 
     // Check the CGW history contains the transaction
     await retry(async () => {


### PR DESCRIPTION
## Changes
- Adds explicit `TransactionResponse` type before calling `.wait()`.